### PR TITLE
Removed the redundant parameter from the RequestGenerateFromKeys struct.

### DIFF
--- a/wallet/structs.go
+++ b/wallet/structs.go
@@ -1033,8 +1033,6 @@ type RequestGenerateFromKeys struct {
 	Password string `json:"password"`
 	// (Optional) If true, save the current wallet before generating the new wallet. (Defaults to true)
 	AutoSaveCurrent bool `json:"autosave_current"`
-	// (Optional) Language for your wallets' seed. (Defaults is "English")
-	Language bool `json:"language"`
 }
 
 // GenerateFromKeys()


### PR DESCRIPTION
A bug was made in the previous edition - the `Language` parameter must not be present in the request, otherwise the RPC server will return the "Invalid params" error.